### PR TITLE
fix: preserve scroll position on rerender

### DIFF
--- a/lib/components/providers/SizesProvider.tsx
+++ b/lib/components/providers/SizesProvider.tsx
@@ -1,7 +1,7 @@
-import { FC, useEffect, useMemo, useState } from 'react';
+import { FC, useEffect, useMemo, useRef, useState } from 'react';
 import { SizesProviderProps } from '.';
 import { SizesContext, UrlParams, useElementContext, useScale } from '../..';
-import { IMAGE_MARGIN, SCALE_DELTA_QUERY_NAME } from '../../constant';
+import { IMAGE_MARGIN, SCALE_DELTA_QUERY_NAME, SCROLL_LEFT_QUERY_NAME, SCROLL_TOP_QUERY_NAME } from '../../constant';
 
 export const SizesProvider: FC<SizesProviderProps> = props => {
   const { children } = props;
@@ -11,6 +11,9 @@ export const SizesProvider: FC<SizesProviderProps> = props => {
   // it only changes again when the user uses the zoom buttons.
   const [scale, setScale] = useState(() => +(UrlParams.get(SCALE_DELTA_QUERY_NAME) ?? '0'));
   const [isMoving, setIsMoving] = useState(false);
+  // Tracks the last zoom delta so we can tell a genuine user zoom (recenter the view)
+  // apart from a remount or defaultScale settling (restore the saved scroll position).
+  const prevScaleRef = useRef(scale);
 
   const canvasHeight = useMemo(() => Math.round((image.height + IMAGE_MARGIN) * (defaultScale + scale)), [defaultScale, image.height, scale]);
 
@@ -20,17 +23,44 @@ export const SizesProvider: FC<SizesProviderProps> = props => {
     UrlParams.set('scale', (defaultScale + scale).toFixed(2));
     UrlParams.set(SCALE_DELTA_QUERY_NAME, scale.toFixed(2));
 
-    if (containerRef.current) {
-      const currentContainer = containerRef.current;
-      const middleY = (currentContainer.scrollHeight - currentContainer.clientHeight) / 2;
-      const middleX = (currentContainer.scrollWidth - currentContainer.clientWidth) / 2;
-      containerRef.current.scrollTo({
-        left: middleX,
-        top: middleY,
-        behavior: 'auto',
-      });
-    }
+    const currentContainer = containerRef.current;
+    if (!currentContainer) return;
+
+    const maxX = currentContainer.scrollWidth - currentContainer.clientWidth;
+    const maxY = currentContainer.scrollHeight - currentContainer.clientHeight;
+
+    const userZoomed = prevScaleRef.current !== scale;
+    prevScaleRef.current = scale;
+
+    // On a genuine zoom, recenter on the image. Otherwise (mount/remount, or defaultScale
+    // settling after the container is measured) restore the previously saved scroll so the
+    // view doesn't jump back to center.
+    const savedX = userZoomed ? null : UrlParams.get(SCROLL_LEFT_QUERY_NAME);
+    const savedY = userZoomed ? null : UrlParams.get(SCROLL_TOP_QUERY_NAME);
+
+    currentContainer.scrollTo({
+      left: savedX !== null ? +savedX * maxX : maxX / 2,
+      top: savedY !== null ? +savedY * maxY : maxY / 2,
+      behavior: 'auto',
+    });
   }, [defaultScale, scale, containerRef]);
+
+  // Persist the scroll position to the URL (as a 0..1 fraction so it survives the canvas
+  // being resized by zoom) so it can be restored after a remount, mirroring how scale is kept.
+  useEffect(() => {
+    const currentContainer = containerRef.current;
+    if (!currentContainer) return () => {};
+
+    const onScroll = () => {
+      const maxX = currentContainer.scrollWidth - currentContainer.clientWidth;
+      const maxY = currentContainer.scrollHeight - currentContainer.clientHeight;
+      UrlParams.set(SCROLL_LEFT_QUERY_NAME, (maxX > 0 ? currentContainer.scrollLeft / maxX : 0).toFixed(4), true);
+      UrlParams.set(SCROLL_TOP_QUERY_NAME, (maxY > 0 ? currentContainer.scrollTop / maxY : 0).toFixed(4), true);
+    };
+
+    currentContainer.addEventListener('scroll', onScroll);
+    return () => currentContainer.removeEventListener('scroll', onScroll);
+  }, [containerRef]);
 
   return (
     <SizesContext.Provider

--- a/lib/constant/variables.ts
+++ b/lib/constant/variables.ts
@@ -9,6 +9,10 @@ export const IMAGE_PADDING = 50;
 export const IMAGE_MARGIN = 600;
 export const SCALE_VALUE_QUERY_NAME = 'scale';
 export const SCALE_DELTA_QUERY_NAME = 'scale-delta';
+// Scroll position is persisted as a 0..1 fraction of the scrollable range so it stays
+// correct across remounts and zoom changes (which resize the scrollable canvas).
+export const SCROLL_LEFT_QUERY_NAME = 'scroll-x';
+export const SCROLL_TOP_QUERY_NAME = 'scroll-y';
 export const CURSOR_SIZE = 3;
 export const DEFAULT_MAIN_COLOR = '#00ff00';
 export const defaultPolygon = { ...getColorFromMain(DEFAULT_MAIN_COLOR), points: [], id: '', surface: 0, measurements: [] };

--- a/lib/utilities/url-params.ts
+++ b/lib/utilities/url-params.ts
@@ -9,9 +9,15 @@ export class UrlParams {
     return this.getUrl().searchParams.get(name);
   }
 
-  public static set(name: string, value: string) {
+  // `replace` swaps pushState for replaceState — use it for high-frequency updates
+  // (e.g. scroll) so the browser history isn't flooded with one entry per event.
+  public static set(name: string, value: string, replace = false) {
     const url = this.getUrl();
     url.searchParams.set(name, value);
-    window.history.pushState({}, '', url);
+    if (replace) {
+      window.history.replaceState({}, '', url);
+    } else {
+      window.history.pushState({}, '', url);
+    }
   }
 }


### PR DESCRIPTION
Scroll position now persists across remounts (saved to the URL as a scale-independent fraction) instead of resetting to center, matching how the zoom level is already preserved. Genuine zoom changes still recenter.